### PR TITLE
[FIX] account, purchase, sale: included taxes

### DIFF
--- a/addons/account/account.py
+++ b/addons/account/account.py
@@ -2170,6 +2170,13 @@ class account_tax(osv.osv):
                 total += r['amount']
         return res
 
+    def _fix_tax_included_price(self, cr, uid, price, prod_taxes, line_taxes):
+        """Subtract tax amount from price when corresponding "price included" taxes do not apply"""
+        incl_tax = [tax for tax in prod_taxes if tax.id not in line_taxes and tax.price_include]
+        if incl_tax:
+            return self._unit_compute_inv(cr, uid, incl_tax, price)[0]['price_unit']
+        return price
+
     def _unit_compute_inv(self, cr, uid, taxes, price_unit, product=None, partner=None):
         taxes = self._applicable(cr, uid, taxes, price_unit,  product, partner)
         res = []

--- a/addons/purchase/purchase.py
+++ b/addons/purchase/purchase.py
@@ -1272,6 +1272,7 @@ class purchase_order_line(osv.osv):
             taxes = product.supplier_taxes_id
         fpos = fiscal_position_id and account_fiscal_position.browse(cr, uid, fiscal_position_id, context=context) or False
         taxes_ids = account_fiscal_position.map_tax(cr, uid, fpos, taxes, context=context)
+        price = self.pool['account.tax']._fix_tax_included_price(cr, uid, price, product.supplier_taxes_id, taxes_ids)
         res['value'].update({'price_unit': price, 'taxes_id': taxes_ids})
 
         return res

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_onchange_product_id

--- a/addons/purchase/tests/test_onchange_product_id.py
+++ b/addons/purchase/tests/test_onchange_product_id.py
@@ -1,0 +1,44 @@
+from openerp.tests.common import TransactionCase
+
+class TestOnchangeProductId(TransactionCase):
+    """Test that when an included tax is mapped by a fiscal position, the included tax must be
+    subtracted to the price of the product.
+    """
+
+    def setUp(self):
+        super(TestOnchangeProductId, self).setUp()
+        self.fiscal_position_model = self.registry('account.fiscal.position')
+        self.fiscal_position_tax_model = self.registry('account.fiscal.position.tax')
+        self.tax_model = self.registry('account.tax')
+        self.pricelist_model = self.registry('product.pricelist')
+        self.res_partner_model = self.registry('res.partner')
+        self.product_tmpl_model = self.registry('product.template')
+        self.product_model = self.registry('product.product')
+        self.product_uom_model = self.registry('product.uom')
+        self.so_line_model = self.registry('purchase.order.line')
+
+    def test_onchange_product_id(self):
+        cr, uid = self.cr, self.uid
+        uom_id = self.product_uom_model.search(cr, uid, [('name', '=', 'Unit(s)')])[0]
+        pricelist = self.pricelist_model.search(cr, uid, [('name', '=', 'Public Pricelist')])[0]
+        partner_id = self.res_partner_model.create(cr, uid, dict(name="George"))
+        tax_include_id = self.tax_model.create(cr, uid, dict(name="Include tax",
+                                                             type='percent',
+                                                             amount='0.21',
+                                                             price_include=True))
+        tax_exclude_id = self.tax_model.create(cr, uid, dict(name="Exclude tax",
+                                                             type='percent',
+                                                             amount='0.00'))
+        product_tmpl_id = self.product_tmpl_model.create(cr, uid, dict(name="Voiture",
+                                                                       list_price='121',
+                                                                       supplier_taxes_id=[(6, 0, [tax_include_id])]))
+        product_id = self.product_model.create(cr, uid, dict(product_tmpl_id=product_tmpl_id))
+        fp_id = self.fiscal_position_model.create(cr, uid, dict(name="fiscal position",
+                                                                sequence=1))
+        fp_tax_id = self.fiscal_position_tax_model.create(cr, uid, dict(position_id=fp_id,
+                                                                        tax_src_id=tax_include_id,
+                                                                        tax_dest_id=tax_exclude_id))
+        res = self.so_line_model.onchange_product_id(cr, uid, [], pricelist, product_id, 1.0, uom_id, partner_id,
+                                                     fiscal_position_id=fp_id)
+
+        self.assertEquals(100, res['value']['price_unit'], "The included tax must be subtracted to the price")

--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -1207,6 +1207,8 @@ class sale_order_line(osv.osv):
 
                 warning_msgs += _("No valid pricelist line found ! :") + warn_msg +"\n\n"
             else:
+                if update_tax:
+                    price = self.pool['account.tax']._fix_tax_included_price(cr, uid, price, product_obj.taxes_id, result['tax_id'])
                 result.update({'price_unit': price})
                 if context.get('uom_qty_change', False):
                     values = {'price_unit': price}

--- a/addons/sale/tests/__init__.py
+++ b/addons/sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_id_change

--- a/addons/sale/tests/test_product_id_change.py
+++ b/addons/sale/tests/test_product_id_change.py
@@ -1,0 +1,41 @@
+from openerp.tests.common import TransactionCase
+
+class TestProductIdChange(TransactionCase):
+    """Test that when an included tax is mapped by a fiscal position, the included tax must be
+    subtracted to the price of the product.
+    """
+
+    def setUp(self):
+        super(TestProductIdChange, self).setUp()
+        self.fiscal_position_model = self.registry('account.fiscal.position')
+        self.fiscal_position_tax_model = self.registry('account.fiscal.position.tax')
+        self.tax_model = self.registry('account.tax')
+        self.pricelist_model = self.registry('product.pricelist')
+        self.res_partner_model = self.registry('res.partner')
+        self.product_tmpl_model = self.registry('product.template')
+        self.product_model = self.registry('product.product')
+        self.so_line_model = self.registry('sale.order.line')
+
+    def test_product_id_change(self):
+        cr, uid = self.cr, self.uid
+        pricelist = self.pricelist_model.search(cr, uid, [('name', '=', 'Public Pricelist')])[0]
+        partner_id = self.res_partner_model.create(cr, uid, dict(name="George"))
+        tax_include_id = self.tax_model.create(cr, uid, dict(name="Include tax",
+                                                             type='percent',
+                                                             amount='0.21',
+                                                             price_include=True))
+        tax_exclude_id = self.tax_model.create(cr, uid, dict(name="Exclude tax",
+                                                             type='percent',
+                                                             amount='0.00'))
+        product_tmpl_id = self.product_tmpl_model.create(cr, uid, dict(name="Voiture",
+                                                                       list_price='121',
+                                                                       taxes_id=[(6, 0, [tax_include_id])]))
+        product_id = self.product_model.create(cr, uid, dict(product_tmpl_id=product_tmpl_id))
+        fp_id = self.fiscal_position_model.create(cr, uid, dict(name="fiscal position",
+                                                                sequence=1))
+        fp_tax_id = self.fiscal_position_tax_model.create(cr, uid, dict(position_id=fp_id,
+                                                                        tax_src_id=tax_include_id,
+                                                                        tax_dest_id=tax_exclude_id))
+        res = self.so_line_model.product_id_change(cr, uid, [], pricelist, product_id, partner_id=partner_id,
+                                                   fiscal_position=fp_id)
+        self.assertEquals(100, res['value']['price_unit'], "The included tax must be subtracted to the price")


### PR DESCRIPTION
-account:_fix_tax_included_price
If a fiscal position mapped an included tax on a SO or on a PO line
then the price unit of the product must be recomputed.

-purchase: onchange_product_id test
Test that when an included tax is mapped by a fiscal position, the included tax must be
subtracted to the price of the product.

-sale:product_id_change test
Test that when an included tax is mapped by a fiscal position, the included tax must be
subtracted to the price of the product.

opw:647321